### PR TITLE
Fixed minoor bug in find_probability_difference

### DIFF
--- a/qnm_filter/utility.py
+++ b/qnm_filter/utility.py
@@ -163,7 +163,7 @@ def find_probability_difference(threshold, array2d):
     tot = logsumexp(array2d)
     region = array2d[array2d > threshold]
     if region.size == 0:
-        prob = 0
+        prob = -100
     else:
         region_tot = logsumexp(region)
         prob = region_tot - tot


### PR DESCRIPTION
find_probability_difference gives the log_probability not the probability directly so if we take input the maximum likelihood it should return `np.log(0) approx -100` not `0`